### PR TITLE
Issue fixed. Model names now have an Orange background when selected,…

### DIFF
--- a/include/gui/mainscreen.h
+++ b/include/gui/mainscreen.h
@@ -120,8 +120,8 @@ Q_SIGNALS:
 private:
 	Ui::MainScreenClass ui;
 
-	double UF_BLUE[3] = {0, 82, 204};
-	double UF_ORANGE[3] = {255, 77, 0};
+	double UF_BLUE[3] = {0, 33, 165};
+	double UF_ORANGE[3] = {250, 70, 22};
 
 	void print_selected_item();
 

--- a/src/gui/drr_tool.cpp
+++ b/src/gui/drr_tool.cpp
@@ -25,7 +25,7 @@ DRRTool::DRRTool(Model model, CameraCalibration calibration, double model_z_plan
 	renderer_ = vtkSmartPointer<vtkRenderer>::New();
 	drr_interactor = vtkSmartPointer<DRRInteractorStyle>::New();
 	drr_interactor->initialize_DRRTool(this);
-	ui.qvtkWidget->GetRenderWindow()->AddRenderer(renderer_);
+	ui.qvtkWidget->renderWindow()->AddRenderer(renderer_);
 	actor_ = vtkSmartPointer<vtkActor>::New();
 	mapper_ = vtkSmartPointer<vtkPolyDataMapper>::New();
 	actor_->GetProperty()->SetColor(214.0 / 255.0, 108.0 / 255.0, 35.0 / 255.0);
@@ -69,7 +69,7 @@ DRRTool::DRRTool(Model model, CameraCalibration calibration, double model_z_plan
 
 	/*Interactor*/
 	drr_interactor->AutoAdjustCameraClippingRangeOff();
-	ui.qvtkWidget->GetRenderWindow()->GetInteractor()->SetInteractorStyle(drr_interactor);
+	ui.qvtkWidget->renderWindow()->GetInteractor()->SetInteractorStyle(drr_interactor);
 
 	/*Initialize Local Image Memory*/
 	host_image_ = static_cast<unsigned char*>(malloc(

--- a/src/gui/mainscreen.cpp
+++ b/src/gui/mainscreen.cpp
@@ -237,7 +237,7 @@ MainScreen::MainScreen(QWidget* parent)
 	actor_image->SetPickable(0);
 	actor_text->SetPickable(0);
 	actor_image->SetMapper(image_mapper);
-	vw->load_render_window(ui.qvtk_widget->GetRenderWindow());
+	vw->load_render_window(ui.qvtk_widget->renderWindow());
 	//vw->load_renderers_into_render_window();
 	ui.qvtk_widget->renderWindow()->Render();
 
@@ -254,7 +254,7 @@ MainScreen::MainScreen(QWidget* parent)
 
 	/*Update*/
 	ui.qvtk_widget->update();
-	ui.qvtk_widget->GetRenderWindow()->Render();
+	ui.qvtk_widget->renderWindow()->Render();
 
 	/*Not Currently Optimizing*/
 	currently_optimizing_ = false;
@@ -985,7 +985,7 @@ void MainScreen::on_actionLoad_Pose_triggered() {
 				vw->set_model_position_at_index(selected[0].row(), loaded_pose.x, loaded_pose.y, loaded_pose.z);
 				vw->set_model_orientation_at_index(selected[0].row(), loaded_pose.xa, loaded_pose.ya, loaded_pose.za);
 				ui.qvtk_widget->update();
-				ui.qvtk_widget->GetRenderWindow()->Render();
+				ui.qvtk_widget->renderWindow()->Render();
 			}
 			else {
 				QMessageBox::critical(this, "Error!", "Invalid Pose!", QMessageBox::Ok);
@@ -1009,7 +1009,7 @@ void MainScreen::on_actionLoad_Pose_triggered() {
 					vw->set_model_position_at_index(selected[0].row(), loaded_pose.x, loaded_pose.y, loaded_pose.z);
 					vw->set_model_orientation_at_index(selected[0].row(), loaded_pose.xa, loaded_pose.ya, loaded_pose.za);
 					ui.qvtk_widget->update();
-					ui.qvtk_widget->GetRenderWindow()->Render();
+					ui.qvtk_widget->renderWindow()->Render();
 				}
 				else {
 					QMessageBox::critical(this, "Error!", "Invalid Pose!", QMessageBox::Ok);
@@ -1186,7 +1186,7 @@ void MainScreen::on_actionReset_View_triggered() {
 				loaded_frames[ui.image_list_widget->currentIndex().row()].GetOriginalImage().rows,
 				true));
 		}
-		ui.qvtk_widget->GetRenderWindow()->GetInteractor()->SetInteractorStyle(key_press_vtk);
+		ui.qvtk_widget->renderWindow()->GetInteractor()->SetInteractorStyle(key_press_vtk);
 		ui.qvtk_widget->update();
 		ui.qvtk_widget->renderWindow()->Render();
 	}
@@ -1215,7 +1215,7 @@ void MainScreen::on_actionReset_View_triggered() {
 			                                           -1 * calibration_file_.camera_A_principal_.principal_distance_ /
 			                                           calibration_file_.camera_A_principal_.pixel_pitch_);
 		}
-		ui.qvtk_widget->GetRenderWindow()->GetInteractor()->SetInteractorStyle(camera_style_interactor);
+		ui.qvtk_widget->renderWindow()->GetInteractor()->SetInteractorStyle(camera_style_interactor);
 		ui.qvtk_widget->update();
 		ui.qvtk_widget->renderWindow()->Render();
 	}
@@ -1235,7 +1235,7 @@ void MainScreen::on_actionModel_Interaction_Mode_triggered() {
 		ui.actionModel_Interaction_Mode->setChecked(true);
 		return;
 	}
-	ui.qvtk_widget->GetRenderWindow()->GetInteractor()->SetInteractorStyle(key_press_vtk);
+	ui.qvtk_widget->renderWindow()->GetInteractor()->SetInteractorStyle(key_press_vtk);
 	ui.qvtk_widget->update();
 	ui.qvtk_widget->renderWindow()->Render();
 };
@@ -1258,7 +1258,7 @@ void MainScreen::on_actionCamera_Interaction_Mode_triggered() {
 		                                           -1 * calibration_file_.camera_A_principal_.principal_distance_ /
 		                                           calibration_file_.camera_A_principal_.pixel_pitch_);
 	}
-	ui.qvtk_widget->GetRenderWindow()->GetInteractor()->SetInteractorStyle(camera_style_interactor);
+	ui.qvtk_widget->renderWindow()->GetInteractor()->SetInteractorStyle(camera_style_interactor);
 	ui.qvtk_widget->update();
 	ui.qvtk_widget->renderWindow()->Render();
 };
@@ -3498,39 +3498,44 @@ void MainScreen::on_model_list_widget_itemSelectionChanged() {
 	else {
 		actor_text->VisibilityOn();
 	}
-	
-	/*Load Models*/
-	for (int i = 0; i < selected.size(); i++) {
-		if (i == 0) {
-			ui.model_list_widget->item(selected[i].row())->setBackgroundColor(QColor(QRgb(UF_ORANGE)));
-			vw->set_3d_model_color(selected[i].row(), UF_ORANGE);
 
+	/*Load Models and set their respective colors in the model list widget*/
+	for (int i = 0; i < selected.size(); i++) {
+
+		// Set a style sheet for selected items in the list widget, controls background colors for .stl model names
+		ui.model_list_widget->setStyleSheet( 
+			"QListView::item{background-color:rgb(0,33,165);}"
+			"QListView::item:selected{background-color: rgb(250,70,22);}" );
+
+		// If first selected item, make the model orange. Otherwise, make it blue.
+		if (i == 0) {
+			vw->set_3d_model_color(selected[i].row(), UF_ORANGE);
 		}
 		else  {
 			//vw->make_model_visible_and_pickable_at_index(i);
 			vw->set_3d_model_color(selected[i].row(), UF_BLUE);
-			ui.model_list_widget->item(selected[i].row())->setBackgroundColor(QColor(QRgb(UF_BLUE)));
 		}
+
 		if (ui.original_model_radio_button->isChecked() == true) {
 			vw->change_model_opacity_to_original(selected[i].row());
 			ui.qvtk_widget->update();
-		ui.qvtk_widget->renderWindow()->Render();
+			ui.qvtk_widget->renderWindow()->Render();
 		}
 		else if (ui.solid_model_radio_button->isChecked() == true) {
 			vw->change_model_opacity_to_solid(selected[i].row());
 			ui.qvtk_widget->update();
-		ui.qvtk_widget->renderWindow()->Render();
+			ui.qvtk_widget->renderWindow()->Render();
 		}
 		else if (ui.transparent_model_radio_button->isChecked() == true) {
 			vw->change_model_opacity_to_transparent(selected[i].row());
 			ui.qvtk_widget->update();
-		ui.qvtk_widget->renderWindow()->Render();
+			ui.qvtk_widget->renderWindow()->Render();
 		}
 		/*Wireframe Model*/
 		else if (ui.wireframe_model_radio_button->isChecked()) {
 			vw->change_model_opacity_to_wire_frame(selected[i].row());
 			ui.qvtk_widget->update();
-		ui.qvtk_widget->renderWindow()->Render();
+			ui.qvtk_widget->renderWindow()->Render();
 		}
 
 		/*If Camera A View*/
@@ -3571,7 +3576,7 @@ void MainScreen::on_model_list_widget_itemSelectionChanged() {
 	}
 	/*Update qvtkWidget*/
 	ui.qvtk_widget->update();
-		ui.qvtk_widget->renderWindow()->Render();
+	ui.qvtk_widget->renderWindow()->Render();
 }
 
 /*Make Selected Actor Principal from VTK*/


### PR DESCRIPTION
… and Blue when not selected.

Issue fixed using a style sheet. Might want to look into using these with other color selections where Qt is being used to streamline?

<img width="166" alt="image" src="https://user-images.githubusercontent.com/49534114/214399199-a6835ef1-a0d6-4289-8306-74d044d4d431.png">
